### PR TITLE
fix: lazy loaded modules

### DIFF
--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -8,11 +8,4 @@ export default defineConfig({
   plugins: [
     pluginPublint(),
   ],
-  tools: {
-    rspack: {
-      optimization: {
-        chunkIds: "named",
-      },
-    },
-  },
 });

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -8,4 +8,11 @@ export default defineConfig({
   plugins: [
     pluginPublint(),
   ],
+  tools: {
+    rspack: {
+      optimization: {
+        chunkIds: "named",
+      },
+    },
+  },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export const pluginAreTheTypesWrong = (
 
         logger.debug(`[arethetypeswrong] Running npm pack from ${rootPath}`);
         const { createTarball } = await import("./create-tarball.js");
-        const tarball = await createTarball(rootPath, packageJson);
+        await using tarball = await createTarball(rootPath, packageJson);
         logger.debug(`[arethetypeswrong] npm pack success`);
 
         const { checkPackage, createPackageFromTarballData } = await import("@arethetypeswrong/core");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { checkPackage, createPackageFromTarballData } from "@arethetypeswrong/core";
 import type { RsbuildPlugin } from "@rsbuild/core";
 
-import { createTarball } from "./create-tarball.js";
-import { render } from "./render/index.js";
 import type { RenderOptions } from "./render/index.js";
 
 export interface PluginAreTheTypesWrongOptions {
@@ -45,11 +42,15 @@ export const pluginAreTheTypesWrong = (
         console.info();
 
         logger.debug(`[arethetypeswrong] Running npm pack from ${rootPath}`);
-        await using tarball = await createTarball(rootPath, packageJson);
+        const { createTarball } = await import("./create-tarball.js");
+        const tarball = await createTarball(rootPath, packageJson);
         logger.debug(`[arethetypeswrong] npm pack success`);
 
+        const { checkPackage, createPackageFromTarballData } = await import("@arethetypeswrong/core");
         const pkg = createPackageFromTarballData(fs.readFileSync(tarball.path));
         const result = await checkPackage(pkg);
+
+        const { render } = await import("./render/index.js");
 
         const message = await render(result, options.areTheTypesWrongOptions ?? {});
         logger.success(message);


### PR DESCRIPTION
Lazy loading modules using `import()`.

This would make loading configuration faster, especially when using `enable: false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved application performance by deferring the loading of certain modules until they are needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->