### PR TITLE
feat: fail the build on type error

### DIFF
--- a/src/getExitCode.ts
+++ b/src/getExitCode.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+Copyright 2023 Andrew Branch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import type { CheckResult } from "@arethetypeswrong/core";
+import { problemFlags } from "./problemUtils.js";
+import type { RenderOptions } from "./render/index.js";
+
+export function getExitCode(analysis: CheckResult, opts?: RenderOptions): 0 | 1 {
+  if (!analysis.types) {
+    return 1;
+  }
+  const ignoreRules = opts?.ignoreRules ?? [];
+  const ignoreResolutions = opts?.ignoreResolutions ?? [];
+  return analysis.problems.some((problem) => {
+      const notRuleIgnored = !ignoreRules.includes(problemFlags[problem.kind]);
+      const notResolutionIgnored = "resolutionKind" in problem
+        ? !ignoreResolutions.includes(problem.resolutionKind)
+        : true;
+      return notRuleIgnored && notResolutionIgnored;
+    })
+    ? 1
+    : 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,10 +61,14 @@ export const pluginAreTheTypesWrong = (
 
         const { getExitCode } = await import("./getExitCode.js");
 
-        const shouldThrow = getExitCode(result, options.areTheTypesWrongOptions) !== 0;
-        if (shouldThrow && !isWatch) {
+        const exitCode = getExitCode(result, options.areTheTypesWrongOptions);
+        const hasErrors = exitCode !== 0;
+        if (hasErrors) {
           logger.error(message);
-          throw new Error("arethetypeswrong failed!");
+          if (!isWatch) {
+            throw new Error("arethetypeswrong failed!");
+          }
+          return;
         }
         logger.success(message);
       },


### PR DESCRIPTION
Throw an error when there are type errors in arethetypeswrong.

The `function getExitCode` is forked from `@arethetypeswrong/cli`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced logic to determine and handle process exit codes based on analysis results, providing clearer feedback during build processes.

* **Bug Fixes**
  * Ensured error handling and process termination occur only on the first compile or single build, preventing unintended behavior in watch mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->