### PR TITLE
chore: release v0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsbuild-plugin-arethetypeswrong",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/colinaaa/rsbuild-plugin-arethetypeswrong.git"


### PR DESCRIPTION
This is the initial release of rsbuild-plugin-arethetypeswrong. Have fun!