### PR TITLE
chore: update pnpm release age exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,10 +5,17 @@ optimisticRepeatInstall: true
 strictDepBuilds: true
 
 minimumReleaseAgeExclude:
-  - "@rspack/*"
   - "@rsbuild/*"
-  - typescript
+  - "@rslib/*"
+  - "@rslint/*"
+  - "@rspack/*"
+  - "@rspress/*"
+  - "@rstackjs/*"
+  - "@rstest/*"
   - "@typescript/*"
+  - "rsbuild-plugin-*"
+  - rstack
+  - typescript
 
 allowBuilds:
   core-js: false


### PR DESCRIPTION
## Summary

This PR updates `minimumReleaseAgeExclude` to exempt Rstack ecosystem packages from pnpm's minimum release age policy. It preserves existing exclusions and sorts the complete list alphabetically.